### PR TITLE
Fix default source for select attribute

### DIFF
--- a/Model/ResourceModel/Seller.php
+++ b/Model/ResourceModel/Seller.php
@@ -255,4 +255,14 @@ class Seller extends \Magento\Eav\Model\Entity\AbstractEntity
 
         return $this->_resource->getConnection()->fetchOne($select);
     }
+
+   /**
+    * Get default attribute source model
+    *
+    * @return string
+    */
+   public function getDefaultAttributeSourceModel()
+   {
+       return 'Magento\Eav\Model\Entity\Attribute\Source\Table';
+   }
 }


### PR DESCRIPTION
Magento did not find default source model for select attribute and throws exception when calling getSource() on attribute model.
