### PR TITLE
Fix bug from factory class generation

### DIFF
--- a/Model/ResourceModel/Seller.php
+++ b/Model/ResourceModel/Seller.php
@@ -201,9 +201,9 @@ class Seller extends \Magento\Eav\Model\Entity\AbstractEntity
         $this->_attributes = [];
         $this->loadAttributesMetadata($attributes);
 
-        $object = $this->getEntityManager()->load($object, $entityId);
+        $object = $this->entityManager->load($object, $entityId);
 
-        if (!$this->getEntityManager()->has($object)) {
+        if (!$this->entityManager->has($object)) {
             $object->isObjectNew(true);
         }
 
@@ -218,7 +218,7 @@ class Seller extends \Magento\Eav\Model\Entity\AbstractEntity
     public function delete($object)
     {
         $this->beforeDelete($object);
-        $this->getEntityManager()->delete($object);
+        $this->entityManager->delete($object);
         $this->afterDelete($object);
 
         return $this;
@@ -236,7 +236,7 @@ class Seller extends \Magento\Eav\Model\Entity\AbstractEntity
     public function save(\Magento\Framework\Model\AbstractModel $object)
     {
         $this->beforeSave($object);
-        $this->getEntityManager()->save($object);
+        $this->entityManager->save($object);
         $this->afterSave($object);
 
         return $this;


### PR DESCRIPTION
When building this class throught Factory process I get this error : <pre>Fatal error: Call to undefined method Smile\Seller\Model\ResourceModel\Seller\Interceptor::getEntityManager() in /var/www/showroom/vendor/smile/module-seller/Model/ResourceModel/Seller.php on line 204</pre>

The method indeed does not appear in the class nor in any of its parents.
So I replaced the `getEntityManager()` by a call to the property `entityManager`.