### PR TITLE
Add Magento_Sales as dependency

### DIFF
--- a/etc/module.xml
+++ b/etc/module.xml
@@ -20,6 +20,7 @@
             <!-- Mandatory to ensure creation of new Entity types is processed
                  after native Magento ones which are using hardcoded entity_type_id -->
             <module name="Magento_Catalog" />
+            <module name="Magento_Sales" />
         </sequence>
     </module>
 </config>


### PR DESCRIPTION
Also add Magento_Sales as dependency to ensure entity creation is done after Magento.

If you have a custom module that make Smile_Retailer/Smile_Seller be load before Magento_Sales, then the same issue with Magento_Catalog happens, because Magento hardcoded their entity type id.

This PR prevent this issue.