### PR TITLE
add missing method to use webapi

### DIFF
--- a/Api/Data/SellerInterface.php
+++ b/Api/Data/SellerInterface.php
@@ -136,6 +136,12 @@ interface SellerInterface extends \Magento\Framework\Api\CustomAttributesDataInt
     public function getAttributeSetName();
 
     /**
+     * @param $ignored
+     * @return mixed
+     */
+    public function setAttributeSetName($ignored);
+
+    /**
      * Get Image name
      *
      * @return string

--- a/Model/Seller.php
+++ b/Model/Seller.php
@@ -258,6 +258,14 @@ class Seller extends \Magento\Framework\Model\AbstractExtensibleModel implements
     /**
      * {@inheritdoc}
      */
+    public function setAttributeSetName($ignored)
+    {
+        return $this;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
     public function getIdentities()
     {
         $identities = [self::CACHE_TAG . '_' . $this->getId()];


### PR DESCRIPTION
This adds a missing method so you can call the bulk webapi inside magento.
So you can call the endpoint created in https://github.com/Smile-SA/magento2-module-retailer/pull/39 .